### PR TITLE
Less 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This port attempts to mirror the source Sass files as closely as possible in ord
 
    Note: The plugins are included using the [`@plugin`](http://lesscss.org/features/#plugin-atrules-feature) at-rule instead of as arguments to the `lessc` CLI. This was intentionally done since most Less GUI compilers don’t allow you to customize the command-line arguments.
 
-0. **Loops** Where possible, Sass `@each` loops have been replaced with the Less `each()` function. Sass `@for` directives are trickier and have no direct Less analog (yet), so they are replaced with the old Less method of looping, which requires a unique, named mixin for every loop. This is a bit clunky, and means that in some places, loops are verbose and difficult to read, but it’s the best we’ve got until we figure out how to do this with a plugin (or Less adds a native equivalent).
+0. **Loops** Where possible, Sass `@each` loops have been replaced with the Less [`each()`](http://lesscss.org/functions/#list-functions-each) function. Sass `@for` directives have been replaced by `each()` together with the [`range()`](http://lesscss.org/functions/#list-functions-range) function.
 
    In order to make catching bugs easier, the Sass versions of most for/each loops have been kept in the code, commented, above the Less versions.
 

--- a/less/mixins/_grid-framework.less
+++ b/less/mixins/_grid-framework.less
@@ -82,13 +82,12 @@
 		@infix: breakpoint-infix(@breakpoint, @breakpoints);
 
 		// Allow columns to stretch full width below their breakpoints
-		#each-column(@i: 1) when (@i <= @columns) {
+		each(range(@columns), #(@i) {
 			.col@{infix}-@{i} {
 				&:extend(.grid-column);
 			}
+		});
 
-			#each-column((@i + 1));
-		} #each-column();
 		.col@{infix},
 		.col@{infix}-auto {
 			&:extend(.grid-column);
@@ -107,35 +106,29 @@
 				max-width: none; // Reset earlier grid tiers
 			}
 
-			#each-column-col(@ii: 1) when (@ii <= @columns) {
-				.col@{infix}-@{ii} {
-					#make-col(@ii, @columns);
+			each(range(@columns), #(@i) {
+				.col@{infix}-@{i} {
+					#make-col(@i, @columns);
 				}
-
-				#each-column-col((@ii + 1));
-			} #each-column-col();
+			});
 
 			.order@{infix}-first { order: -1; }
 
 			.order@{infix}-last { order: (@columns + 1); }
 
-			#each-column-order(@ii: 0) when (@ii <= @columns) {
-				.order@{infix}-@{ii} { order: @ii; }
+			each(range(0, @columns), #(@i) {
+				.order@{infix}-@{i} { order: @i; }
+			});
 
-				#each-column-order((@ii + 1));
-			} #each-column-order();
-
-			// `@ii < @columns` because offsetting by the width of an entire row isn't possible
-			#each-column-offset(@ii: 0) when (@ii < @columns) {
-				& when not (@ii = 0),
-				(@ii = 0) and not (@infix = ~"") {
-					.offset@{infix}-@{ii} {
-						#make-col-offset(@ii, @columns);
+			// `@columns - 1` because offsetting by the width of an entire row isn't possible
+			each(range(0, (@columns - 1)), #(@i) {
+				& when not (@i = 0),
+				(@i = 0) and not (@infix = ~"") {
+					.offset@{infix}-@{i} {
+						#make-col-offset(@i, @columns);
 					}
 				}
-
-				#each-column-offset((@ii + 1));
-			} #each-column-offset();
+			});
 		});
 	});
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"lint": "eslint ."
 	},
 	"peerDependencies": {
-		"less": "^3.8.1"
+		"less": "^3.9.0"
 	},
 	"devDependencies": {
 		"autoprefixer": "^8.6.5",


### PR DESCRIPTION
Replaces #9 and #12, and updates `#for-*` mixin loops with `each(range(@list))` allowed in 3.9.  Also bumps required versions to 3.9.  It bumps the npm package version to 0.4.0.

Thanks to @matthew-dean for the updates to the README and package.json that I stole from his PR.

This also fixes the issue where `.table-responsive` was being output out-of-order.

This changes the min required version of Less to v3.9 (to support `range()`).